### PR TITLE
Fix download path for resnext and wideresnet models

### DIFF
--- a/pretrainedmodels/resnext.py
+++ b/pretrainedmodels/resnext.py
@@ -1,6 +1,6 @@
 import os
 from os.path import expanduser
-import collections 
+import collections
 import torch
 import torch.nn as nn
 from torch.autograd import Variable
@@ -73,12 +73,12 @@ def resnext101_32x4d(num_classes=1000, pretrained='imagenet'):
         settings = pretrained_settings['resnext101_32x4d'][pretrained]
         assert num_classes == settings['num_classes'], \
             "num_classes should be {}, but is {}".format(settings['num_classes'], num_classes)
-       
+
         dir_models = os.path.join(expanduser("~"), '.torch/resnext')
         path_pth = os.path.join(dir_models, 'resnext101_32x4d.pth')
         if not os.path.isfile(path_pth):
             os.system('mkdir -p ' + dir_models)
-            os.system('wget {} {}'.format(settings['url'], path_pth))
+            os.system('wget {} -O {}'.format(settings['url'], path_pth))
         state_dict_features = torch.load(path_pth)
         state_dict_fc = collections.OrderedDict()
         state_dict_fc['weight'] = state_dict_features['10.1.weight']
@@ -101,12 +101,12 @@ def resnext101_64x4d(num_classes=1000, pretrained='imagenet'):
         settings = pretrained_settings['resnext101_64x4d'][pretrained]
         assert num_classes == settings['num_classes'], \
             "num_classes should be {}, but is {}".format(settings['num_classes'], num_classes)
-       
+
         dir_models = os.path.join(expanduser("~"), '.torch/resnext')
         path_pth = os.path.join(dir_models, 'resnext101_64x4d.pth')
         if not os.path.isfile(path_pth):
             os.system('mkdir -p ' + dir_models)
-            os.system('wget {} {}'.format(settings['url'], path_pth))
+            os.system('wget {} -O {}'.format(settings['url'], path_pth))
         state_dict_features = torch.load(path_pth)
         state_dict_fc = collections.OrderedDict()
         state_dict_fc['weight'] = state_dict_features['10.1.weight']

--- a/pretrainedmodels/wideresnet.py
+++ b/pretrainedmodels/wideresnet.py
@@ -32,7 +32,7 @@ def define_model(params):
                 o += x
             o = F.relu(o)
         return o
-    
+
     # determine network size by parameters
     blocks = [sum([re.match('group%d.block\d+.conv0.weight'%j, k) is not None
                    for k in params.keys()]) for j in range(4)]
@@ -60,7 +60,7 @@ class WideResNet(nn.Module):
         super(WideResNet, self).__init__()
         self.pooling = pooling
         self.params = params
-        
+
     def forward(self, x):
         x = f(x, self.params, self.pooling)
         return x
@@ -77,7 +77,7 @@ def wideresnet50(pooling):
             params[k] = Variable(torch.from_numpy(v), requires_grad=True)
     else:
         os.system('mkdir -p ' + dir_models)
-        os.system('wget {} {}'.format(model_urls['wideresnet50'], path_hkl))
+        os.system('wget {} -O {}'.format(model_urls['wideresnet50'], path_hkl))
     f = define_model(params)
     model = WideResNet(pooling)
     return model


### PR DESCRIPTION
The code used to call wget with a command line that made it
download the .pth-files into the current working directory instead of
the model path, causing the .pth-files to not be found. The '-O'
parameter was added to wget to make it download the files to the correct
location.