### PR TITLE
Revert all changes on Separable Convolutions.

### DIFF
--- a/pretrainedmodels/nasnet.py
+++ b/pretrainedmodels/nasnet.py
@@ -3,12 +3,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.autograd import Variable
 
-# Faster implementation of the separable convolution
-# Won't work if you don't have the last version of pytorch (from master)
-# https://github.com/pytorch/vision/issues/321#issuecomment-342207053
-# https://github.com/pytorch/pytorch/pull/3057
-_PYTORCH_MASTER = False
-
 class SeparableConv2d(nn.Module):
 
     def __init__(self, in_channels, out_channels, dw_kernel, dw_stride, dw_padding, bias=False):
@@ -30,30 +24,6 @@ class TwoSeparables(nn.Module):
 
     def __init__(self, in_channels, out_channels, dw_kernel, dw_stride, dw_padding, bias=False):
         super(TwoSeparables, self).__init__()
-        if _PYTORCH_MASTER:
-            self.separable_0 = nn.Conv2d(in_channels, out_channels, dw_kernel, dw_stride, dw_padding, bias=bias, groups=in_channels)
-        else:
-            self.separable_0 = SeparableConv2d(in_channels, in_channels, dw_kernel, dw_stride, dw_padding, bias=bias)
-        self.bn_0 = nn.BatchNorm2d(in_channels, eps=0.001, momentum=0.1, affine=True)
-        if _PYTORCH_MASTER:
-            self.separable_1 = nn.Conv2d(in_channels, out_channels, dw_kernel, 1, dw_padding, bias=bias, groups=in_channels)
-        else:
-            self.separable_1 = SeparableConv2d(in_channels, out_channels, dw_kernel, 1, dw_padding, bias=bias)
-        self.bn_1 = nn.BatchNorm2d(out_channels, eps=0.001, momentum=0.1, affine=True)
-
-    def forward(self, x):
-        x = F.relu(x)
-        x = self.separable_0(x)
-        x = self.bn_0(x)
-        x = F.relu(x)
-        x = self.separable_1(x)
-        x = self.bn_1(x)
-        return x
-
-class TwoSeparablesReduction(nn.Module):
-
-    def __init__(self, in_channels, out_channels, dw_kernel, dw_stride, dw_padding, bias=False):
-        super(TwoSeparablesReduction, self).__init__()
         self.separable_0 = SeparableConv2d(in_channels, in_channels, dw_kernel, dw_stride, dw_padding, bias=bias)
         self.bn_0 = nn.BatchNorm2d(in_channels, eps=0.001, momentum=0.1, affine=True)
         self.separable_1 = SeparableConv2d(in_channels, out_channels, dw_kernel, 1, dw_padding, bias=bias)
@@ -77,13 +47,13 @@ class CellStem0(nn.Module):
         self.bn_0 = nn.BatchNorm2d(42, eps=0.001, momentum=0.1, affine=True)
 
         self.comb_iter_0_left = TwoSeparables(42, 42, 5, 2, 2, bias=False)
-        self.comb_iter_0_right = TwoSeparablesReduction(96, 42, 7, 2, 3, bias=False)
+        self.comb_iter_0_right = TwoSeparables(96, 42, 7, 2, 3, bias=False)
 
         self.comb_iter_1_left = nn.AvgPool2d(3, stride=2, padding=1)
-        self.comb_iter_1_right = TwoSeparablesReduction(96, 42, 7, 2, 3, bias=False)
+        self.comb_iter_1_right = TwoSeparables(96, 42, 7, 2, 3, bias=False)
 
         self.comb_iter_2_left = nn.MaxPool2d(3, stride=2, padding=1)
-        self.comb_iter_2_right = TwoSeparablesReduction(96, 42, 5, 2, 2, bias=False)
+        self.comb_iter_2_right = TwoSeparables(96, 42, 5, 2, 2, bias=False)
 
         self.comb_iter_3_right = nn.AvgPool2d(3, stride=1, padding=1)
 


### PR DESCRIPTION
Pytorch master doesn't fuse Conv and Pointwise and can only perform filter mutiplication.

Fixes https://github.com/Cadene/pretrained-models.pytorch/issues/16