### PR TITLE
Adding tqdm and a newline at the end of requirements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 torch
 torchvision
 munch
+tqdm


### PR DESCRIPTION
The module requires tqdm, which is not default in Anaconda.