### PR TITLE
Updated inceptionV4 to accept different sized images

### DIFF
--- a/pretrainedmodels/models/inceptionv4.py
+++ b/pretrainedmodels/models/inceptionv4.py
@@ -301,7 +301,6 @@ class InceptionV4(nn.Module):
         #Allows image of any size to be processed
         adaptiveAvgPoolWidth = features.shape[2]
         x = F.avg_pool2d(features, kernel_size=adaptiveAvgPoolWidth)
-        x = self.avg_pool(features)
         x = x.view(x.size(0), -1)
         x = self.last_linear(x)
         return x

--- a/pretrainedmodels/models/inceptionv4.py
+++ b/pretrainedmodels/models/inceptionv4.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division, absolute_import
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 import torch.utils.model_zoo as model_zoo
 import os
 import sys

--- a/pretrainedmodels/models/inceptionv4.py
+++ b/pretrainedmodels/models/inceptionv4.py
@@ -295,7 +295,6 @@ class InceptionV4(nn.Module):
             Inception_C(),
             Inception_C()
         )
-        self.avg_pool = nn.AvgPool2d(8, count_include_pad=False)
         self.last_linear = nn.Linear(1536, num_classes)
 
     def logits(self, features):

--- a/pretrainedmodels/models/inceptionv4.py
+++ b/pretrainedmodels/models/inceptionv4.py
@@ -298,6 +298,9 @@ class InceptionV4(nn.Module):
         self.last_linear = nn.Linear(1536, num_classes)
 
     def logits(self, features):
+        #Allows image of any size to be processed
+        adaptiveAvgPoolWidth = features.shape[2]
+        x = F.avg_pool2d(features, kernel_size=adaptiveAvgPoolWidth)
         x = self.avg_pool(features)
         x = x.view(x.size(0), -1)
         x = self.last_linear(x)


### PR DESCRIPTION
The update allows inceptionV4 to process images larger or smaller than prescribed image size (299x299). Will be useful while finetuning or testing on different resolution images.