### PR TITLE
Python 2 float/integer compatibility fix

### DIFF
--- a/pretrainedmodels/__init__.py
+++ b/pretrainedmodels/__init__.py
@@ -7,7 +7,7 @@ from .models.utils import pretrained_settings
 from .models.utils import model_names
 
 # to support pretrainedmodels.__dict__['nasnetalarge']
-# but depreciated
+# but deprecated
 from .models.fbresnet import fbresnet152
 from .models.cafferesnet import cafferesnet101
 from .models.bninception import bninception

--- a/pretrainedmodels/models/senet.py
+++ b/pretrainedmodels/models/senet.py
@@ -189,7 +189,7 @@ class SEResNeXtBottleneck(Bottleneck):
     def __init__(self, inplanes, planes, groups, reduction, stride=1,
                  downsample=None, base_width=4):
         super(SEResNeXtBottleneck, self).__init__()
-        width = math.floor(planes * (base_width / 64)) * groups
+        width = int(math.floor(planes * (base_width / 64)) * groups)
         self.conv1 = nn.Conv2d(inplanes, width, kernel_size=1, bias=False,
                                stride=1)
         self.bn1 = nn.BatchNorm2d(width)

--- a/pretrainedmodels/version.py
+++ b/pretrainedmodels/version.py
@@ -1,2 +1,2 @@
 from __future__ import print_function, division, absolute_import
-__version__ = '0.7.4'
+__version__ = '0.7.5'


### PR DESCRIPTION
This fixes se_resnext models where `math.floor` is used to compute layer width. In Python 3 this outs an integer, but in 2.7 this outputs a float. This fix makes sure an int is always supplied.