### PR TITLE
fix 0-dim tensor  error

### DIFF
--- a/examples/imagenet_logits.py
+++ b/examples/imagenet_logits.py
@@ -62,7 +62,7 @@ def main():
         # Make predictions
         output = model(input) # size(1, 1000)
         max, argmax = output.data.squeeze().max(0)
-        class_id = argmax[0]
+        class_id = argmax.item()
         class_key = class_id_to_key[class_id]
         classname = key_to_classname[class_key]
 


### PR DESCRIPTION
Use tensor.item() to convert a 0-dim tensor to a Python number