### PR TITLE
Delete fc layer in ResNet

### DIFF
--- a/pretrainedmodels/models/torchvision_models.py
+++ b/pretrainedmodels/models/torchvision_models.py
@@ -314,7 +314,7 @@ def inceptionv3(num_classes=1000, pretrained='imagenet'):
 def modify_resnets(model):
     # Modify attributs
     model.last_linear = model.fc
-    model.fc = None
+    del model.fc
 
     def features(self, input):
         x = self.conv1(input)


### PR DESCRIPTION
Removed a fully connected layer in the resnet models instead of installing None. Same in VGG.